### PR TITLE
Support new FTP structure + output directory

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -82,7 +82,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install nf-core
+          pip install nf-core==2.5.0
 
       - name: Run nf-core lint
         env:

--- a/.nf-core.yml
+++ b/.nf-core.yml
@@ -12,6 +12,7 @@ lint:
     - .github/workflows/awsfulltest.yml
   files_unchanged:
     - LICENSE
+    - .gitattributes
     - .github/CONTRIBUTING.md
     - .github/ISSUE_TEMPLATE/bug_report.yml
     - .github/workflows/linting.yml

--- a/assets/samplesheet.csv
+++ b/assets/samplesheet.csv
@@ -1,5 +1,5 @@
-species_dir,assembly_name,assembly_accession,ensembl_species_name
-25g/data/echinoderms/Asterias_rubens,eAstRub1.3,GCA_902459465.3,Asterias_rubens
-25g/data/insects/Osmia_bicornis,iOsmBic2.1,GCA_907164935.1,Osmia_bicornis_bicornis
-25g/data/insects/Osmia_bicornis,iOsmBic2.1_alternate_haplotype,GCA_907164925.1,Osmia_bicornis_bicornis
-darwin/data/insects/Noctua_fimbriata,ilNocFimb1.1,GCA_905163415.1,Noctua_fimbriata
+species_dir,assembly_name,assembly_accession,ensembl_species_name,annotation_method
+25g/data/echinoderms/Asterias_rubens,eAstRub1.3,GCA_902459465.3,Asterias_rubens,refseq
+25g/data/insects/Osmia_bicornis,iOsmBic2.1,GCA_907164935.1,Osmia_bicornis_bicornis,ensembl
+25g/data/insects/Osmia_bicornis,iOsmBic2.1_alternate_haplotype,GCA_907164925.1,Osmia_bicornis_bicornis,ensembl
+darwin/data/insects/Noctua_fimbriata,ilNocFimb1.1,GCA_905163415.1,Noctua_fimbriata,braker

--- a/assets/schema_input.json
+++ b/assets/schema_input.json
@@ -25,9 +25,14 @@
             "ensembl_species_name": {
                 "type": "string",
                 "pattern": "^\\S+$",
-                "errorMessage": "Name of the species, as used in the Ensembl FTP"
+                "errorMessage": "The (Ensembl) species name must be provided and cannot contain spaces"
+            },
+            "annotation_method": {
+                "type": "string",
+                "pattern": "^\\S+$",
+                "errorMessage": "The annotation method must be provided and cannot contain spaces"
             }
         },
-        "required": ["species_dir", "assembly_name", "ensembl_species_name"]
+        "required": ["species_dir", "assembly_name", "ensembl_species_name", "annotation_method"]
     }
 }

--- a/conf/test.config
+++ b/conf/test.config
@@ -20,5 +20,6 @@ params {
     max_time   = '6.h'
 
     ensembl_species_name = "Osmia_bicornis_bicornis"
-    assembly_accession   = "GCA_907164935.1"
+    assembly_accession   = "GCA_907164925.1"
+    annotation_method    = "ensembl"
 }

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -33,7 +33,7 @@ darwin/data/insects/Noctua_fimbriata,ilNocFimb1.1,GCA_905163415.1,Noctua_fimbria
 
 | Column                 | Description                                                                                                                                                |
 | ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `species_dir`          | Output directory for this species (evaluated from the current directory if a relative path). Analysis results are deposited in `analysis/$assembly_name/`. |
+| `species_dir`          | Output directory for this species (evaluated from `--outdir` if a relative path). Analysis results are deposited in `analysis/$assembly_name/`.            |
 | `assembly_name`        | Name of the assembly. Used to build the actual output directory.                                                                                           |
 | `assembly_accession`   | (Optional). Accession number of the assembly to download. Typically of the form `GCA_*.*`. If missing, the pipeline will infer it from the ACCESSION file. |
 | `ensembl_species_name` | Name of the species, _as used by Ensembl_. Note: it may differ from Tree of Life's                                                                         |

--- a/lib/NfcoreTemplate.groovy
+++ b/lib/NfcoreTemplate.groovy
@@ -228,7 +228,7 @@ class NfcoreTemplate {
             ${colors.blue} | (___   __ _ _ __   __ _  ___ _ __ ${colors.reset}______${colors.green}| |${colors.yellow} ___ ${colors.red}| |${colors.reset}
             ${colors.blue}  \\___ \\ / _` | '_ \\ / _` |/ _ \\ '__|${colors.reset}______${colors.green}| |${colors.yellow}/ _ \\${colors.red}| |${colors.reset}
             ${colors.blue}  ____) | (_| | | | | (_| |  __/ |         ${colors.green}| |${colors.yellow} (_) ${colors.red}| |____${colors.reset}
-            ${colors.blue} |_____/ \\__,_|_| |_|\\__, |\\___|_|         ${colors.green}|_|${colors.yellow}\\___/${colors.red}}|______|${colors.reset}
+            ${colors.blue} |_____/ \\__,_|_| |_|\\__, |\\___|_|         ${colors.green}|_|${colors.yellow}\\___/${colors.red}|______|${colors.reset}
             ${colors.blue}                      __/ |${colors.reset}
             ${colors.blue}                     |___/${colors.reset}
             ${colors.purple}  ${workflow.manifest.name} v${workflow.manifest.version}${colors.reset}

--- a/lib/WorkflowEnsemblrepeatdownload.groovy
+++ b/lib/WorkflowEnsemblrepeatdownload.groovy
@@ -17,8 +17,8 @@ class WorkflowEnsemblrepeatdownload {
                 System.exit(1)
             }
         } else {
-            if (!params.assembly_accession || !params.ensembl_species_name || !params.outdir) {
-                log.error "Either --input, or --assembly_accession, --assembly_name, and --outdir must be provided"
+            if (!params.assembly_accession || !params.ensembl_species_name || !params.annotation_method || !params.outdir) {
+                log.error "Either --input, or --assembly_accession, --assembly_name, --annotation_method, and --outdir must be provided"
                 System.exit(1)
             }
         }

--- a/lib/WorkflowEnsemblrepeatdownload.groovy
+++ b/lib/WorkflowEnsemblrepeatdownload.groovy
@@ -17,10 +17,14 @@ class WorkflowEnsemblrepeatdownload {
                 System.exit(1)
             }
         } else {
-            if (!params.assembly_accession || !params.ensembl_species_name || !params.annotation_method || !params.outdir) {
-                log.error "Either --input, or --assembly_accession, --assembly_name, --annotation_method, and --outdir must be provided"
+            if (!params.assembly_accession || !params.ensembl_species_name || !params.annotation_method) {
+                log.error "Either --input, or --assembly_accession, --assembly_name, and --annotation_method must be provided"
                 System.exit(1)
             }
+        }
+        if (!params.outdir) {
+            log.error "--outdir is mandatory"
+            System.exit(1)
         }
     }
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -13,6 +13,7 @@ params {
     input                      = null
     assembly_accession         = null
     ensembl_species_name       = null
+    annotation_method          = null
     ftp_root                   = "https://ftp.ensembl.org/pub/rapid-release/species"
 
     // Boilerplate options

--- a/nextflow.config
+++ b/nextflow.config
@@ -17,7 +17,7 @@ params {
     ftp_root                   = "https://ftp.ensembl.org/pub/rapid-release/species"
 
     // Boilerplate options
-    outdir                     = null
+    outdir                     = 'results'
     tracedir                   = "${params.outdir}/pipeline_info"
     publish_dir_mode           = 'copy'
     email                      = null

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -24,6 +24,12 @@
                     "pattern": "^\\S+$",
                     "fa_icon": "fas fa-italic"
                 },
+                "annotation_method": {
+                    "type": "string",
+                    "description": "Method used to annotate the genome. Typically `ensembl`, `braker`, etc.",
+                    "pattern": "^\\S+$",
+                    "fa_icon": "fas fa-book"
+                },
                 "outdir": {
                     "type": "string",
                     "format": "directory-path",
@@ -37,7 +43,7 @@
                     "pattern": "^\\S+\\.csv$",
                     "schema": "assets/schema_input.json",
                     "description": "Path to comma-separated file containing information about the assemblies to download. Used for bulk download of many assemblies.",
-                    "help_text": "The file has to be a comma-separated file with three columns, and a header row. The columns names must be `species_dir`, `assembly_name`, and `ensembl_species_name`. An additional `assembly_accession` column can be provided too.",
+                    "help_text": "The file has to be a comma-separated file with five columns, and a header row. The columns names must be `species_dir`, `assembly_name`, `ensembl_species_name`, and `annotation_method`. An additional `assembly_accession` column can be provided too.",
                     "fa_icon": "fas fa-file-csv"
                 },
                 "ftp_root": {

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -33,7 +33,8 @@
                 "outdir": {
                     "type": "string",
                     "format": "directory-path",
-                    "description": "The output directory where the results will be saved. Not considered when running the pipeline with a .csv file as input.",
+                    "description": "The output directory where the results will be saved. Not considered for sample-sheet entries that have an absolute path.",
+                    "default": "results",
                     "fa_icon": "fas fa-folder-open"
                 },
                 "input": {

--- a/subworkflows/local/download.nf
+++ b/subworkflows/local/download.nf
@@ -8,7 +8,7 @@ include { ENSEMBL_GENOME_DOWNLOAD       } from '../../modules/local/ensembl_geno
 workflow DOWNLOAD {
 
     take:
-    repeat_params  // tuple(analysis_dir, ensembl_species_name, assembly_accession)
+    repeat_params  // tuple(analysis_dir, ensembl_species_name, assembly_accession, annotation_method)
 
 
     main:
@@ -19,11 +19,12 @@ workflow DOWNLOAD {
             // meta
             [
                 id: it[2] + ".masked.ensembl",
+                method: it[3],
                 outdir: it[0],
             ],
-            // e.g. https://ftp.ensembl.org/pub/rapid-release/species/Agriopis_aurantiaria/GCA_914767915.1/genome/Agriopis_aurantiaria-GCA_914767915.1-softmasked.fa.gz
+            // e.g. https://ftp.ensembl.org/pub/rapid-release/species/Agriopis_aurantiaria/GCA_914767915.1/braker/genome/Agriopis_aurantiaria-GCA_914767915.1-softmasked.fa.gz
             // ftp_path
-            params.ftp_root + "/" + it[1] + "/" + it[2] + "/genome",
+            params.ftp_root + "/" + it[1] + "/" + it[2] + "/" + it[3] + "/genome",
             // remote_filename_stem
             it[1] + "-" + it[2],
         ] },

--- a/subworkflows/local/download.nf
+++ b/subworkflows/local/download.nf
@@ -15,19 +15,37 @@ workflow DOWNLOAD {
     ch_versions = Channel.empty()
 
     ch_genome_fasta     = ENSEMBL_GENOME_DOWNLOAD (
-        repeat_params.map { [
-            // meta
-            [
-                id: it[2] + ".masked.ensembl",
-                method: it[3],
-                outdir: it[0],
-            ],
-            // e.g. https://ftp.ensembl.org/pub/rapid-release/species/Agriopis_aurantiaria/GCA_914767915.1/braker/genome/Agriopis_aurantiaria-GCA_914767915.1-softmasked.fa.gz
-            // ftp_path
-            params.ftp_root + "/" + it[1] + "/" + it[2] + "/" + it[3] + "/genome",
-            // remote_filename_stem
-            it[1] + "-" + it[2],
-        ] },
+        repeat_params.map {
+            species_dir,
+            ensembl_species_name,
+            assembly_accession,
+            annotation_method
+
+            -> [
+                // meta
+                [
+                    id: assembly_accession + ".masked.ensembl",
+                    method: annotation_method,
+                    outdir: species_dir,
+                ],
+
+                // e.g. https://ftp.ensembl.org/pub/rapid-release/species/Agriopis_aurantiaria/GCA_914767915.1/braker/genome/Agriopis_aurantiaria-GCA_914767915.1-softmasked.fa.gz
+                // ftp_path
+                [
+                    params.ftp_root,
+                    ensembl_species_name,
+                    assembly_accession,
+                    annotation_method,
+                    "genome",
+                ].join("/"),
+
+                // remote_filename_stem
+                [
+                    ensembl_species_name,
+                    assembly_accession,
+                ].join("-"),
+            ]
+        },
     ).fasta
     ch_versions         = ch_versions.mix(ENSEMBL_GENOME_DOWNLOAD.out.versions.first())
 

--- a/subworkflows/local/params_check.nf
+++ b/subworkflows/local/params_check.nf
@@ -9,6 +9,7 @@ workflow PARAMS_CHECK {
     take:
     samplesheet  // file
     cli_params   // tuple, see below
+    outdir       // file output directory
 
 
     main:
@@ -28,7 +29,7 @@ workflow PARAMS_CHECK {
             }
             // Convert to tuple, as required by the download subworkflow
             .map { [
-                "${it["species_dir"]}/analysis/${it["assembly_name"]}",
+                (it["species_dir"].startsWith("/") ? "" : outdir + "/") + "${it["species_dir"]}/analysis/${it["assembly_name"]}",
                 it["ensembl_species_name"],
                 it["assembly_accession"],
                 it["annotation_method"],

--- a/subworkflows/local/params_check.nf
+++ b/subworkflows/local/params_check.nf
@@ -40,7 +40,7 @@ workflow PARAMS_CHECK {
 
     } else {
         // Add the other input channel in, as it's expected to have all the parameters in the right order
-        ch_inputs = ch_inputs.mix(cli_params)
+        ch_inputs = ch_inputs.mix(cli_params.map { [outdir] + it } )
     }
 
     emit:

--- a/subworkflows/local/params_check.nf
+++ b/subworkflows/local/params_check.nf
@@ -18,7 +18,7 @@ workflow PARAMS_CHECK {
     if (samplesheet) {
         SAMPLESHEET_CHECK ( file(samplesheet, checkIfExists: true) )
             .csv
-            // Provides species_dir, assembly_name, assembly_accession (optional), and ensembl_species_name
+            // Provides species_dir, assembly_name, assembly_accession (optional), ensembl_species_name, and annotation_method
             .splitCsv ( header:true, sep:',' )
             .map {
                 // If assembly_accession is missing, load the accession number from file, following the Tree of Life directory structure
@@ -31,6 +31,7 @@ workflow PARAMS_CHECK {
                 "${it["species_dir"]}/analysis/${it["assembly_name"]}",
                 it["ensembl_species_name"],
                 it["assembly_accession"],
+                it["annotation_method"],
             ] }
             .set { ch_inputs }
 
@@ -42,7 +43,7 @@ workflow PARAMS_CHECK {
     }
 
     emit:
-    ensembl_params  = ch_inputs        // tuple(analysis_dir, ensembl_species_name, assembly_accession)
+    ensembl_params  = ch_inputs        // tuple(analysis_dir, ensembl_species_name, assembly_accession, annotation_method)
     versions        = ch_versions      // channel: versions.yml
 }
 

--- a/workflows/ensemblrepeatdownload.nf
+++ b/workflows/ensemblrepeatdownload.nf
@@ -51,6 +51,7 @@ workflow ENSEMBLREPEATDOWNLOAD {
                 params.outdir,
                 params.ensembl_species_name,
                 params.assembly_accession,
+                params.annotation_method,
             ]
         ),
     )

--- a/workflows/ensemblrepeatdownload.nf
+++ b/workflows/ensemblrepeatdownload.nf
@@ -48,12 +48,12 @@ workflow ENSEMBLREPEATDOWNLOAD {
         params.input,
         Channel.of(
             [
-                params.outdir,
                 params.ensembl_species_name,
                 params.assembly_accession,
                 params.annotation_method,
             ]
         ),
+        params.outdir,
     )
     ch_versions         = ch_versions.mix(PARAMS_CHECK.out.versions)
 


### PR DESCRIPTION
https://jira.sanger.ac.uk/browse/TOLIT-954

Ensembl have now introduced an extra directory level on their FTP to indicate the annotation method: https://www.ensembl.info/2022/11/08/updates-to-the-ensembl-rapid-release-ftp-site/

This pipeline too needs to be aware of the _gene_ annotation method, even if the _repeat_ annotation is the same regardless of the gene annotation method. That's a requirement of the FTP directory structure.
This PR simply adds the extra parameter, and as in https://github.com/sanger-tol/ensemblgenedownload/pull/2 changes the way relative output paths from the sample-sheet are interpreted 

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/sanger-tol/ensemblrepeatdownload/tree/master/.github/CONTRIBUTING.md)
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [x] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [x] `README.md` is updated (including new tool citations and authors/contributors).
