### PR TITLE
Rework of the output directories

### DIFF
--- a/assets/samplesheet.csv
+++ b/assets/samplesheet.csv
@@ -1,5 +1,5 @@
-species_dir,assembly_name,assembly_accession,ensembl_species_name,annotation_method
-25g/data/echinoderms/Asterias_rubens,eAstRub1.3,GCA_902459465.3,Asterias_rubens,refseq
-25g/data/insects/Osmia_bicornis,iOsmBic2.1,GCA_907164935.1,Osmia_bicornis_bicornis,ensembl
-25g/data/insects/Osmia_bicornis,iOsmBic2.1_alternate_haplotype,GCA_907164925.1,Osmia_bicornis_bicornis,ensembl
-darwin/data/insects/Noctua_fimbriata,ilNocFimb1.1,GCA_905163415.1,Noctua_fimbriata,braker
+outdir,assembly_accession,ensembl_species_name,annotation_method
+Asterias_rubens/eAstRub1.3,GCA_902459465.3,Asterias_rubens,refseq
+Osmia_bicornis/iOsmBic2.1,GCA_907164935.1,Osmia_bicornis_bicornis,ensembl
+Osmia_bicornis/iOsmBic2.1_alternate_haplotype,GCA_907164925.1,Osmia_bicornis_bicornis,ensembl
+Noctua_fimbriata/ilNocFimb1.1,GCA_905163415.1,Noctua_fimbriata,braker

--- a/assets/schema_input.json
+++ b/assets/schema_input.json
@@ -7,15 +7,10 @@
     "items": {
         "type": "object",
         "properties": {
-            "species_dir": {
+            "outdir": {
                 "type": "string",
                 "pattern": "^\\S+$",
                 "errorMessage": "Species directory must be provided and exist"
-            },
-            "assembly_name": {
-                "type": "string",
-                "pattern": "^\\S+$",
-                "errorMessage": "Assembly name must be provided and cannot contain spaces"
             },
             "assembly_accession": {
                 "type": "string",
@@ -33,6 +28,6 @@
                 "errorMessage": "The annotation method must be provided and cannot contain spaces"
             }
         },
-        "required": ["species_dir", "assembly_name", "ensembl_species_name", "annotation_method"]
+        "required": ["outdir", "assembly_accession", "ensembl_species_name", "annotation_method"]
     }
 }

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -16,7 +16,7 @@ The pipeline accepts command-one line arguments to specify a single genome to do
 - `--ensembl_species_name`: How Ensembl name the species (as it can be different from Tree of Life),
 - `--assembly_accession`: The accession number of the assembly,
 - `--annotation_method`: The annotation method of the geneset related to the repeat annotation (requirement of Ensembl's data-model),
-- `--outdir`: Where to download the data.
+- `--outdir`: Where the pipeline runtime information will be stored, and where data will be downloaded (except if absolute paths are given in the samplesheet).
 
 ```console
 nextflow run sanger-tol/ensemblrepeatdownload -profile singularity --ensembl_species_name Noctua_fimbriata --assembly_accession GCA_905163415.1 --annotation_method braker --outdir Noctua_fimbriata_repeats

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -44,23 +44,22 @@ Current annotation methods include:
 ## Bulk download
 
 The pipeline can download multiple assemblies at once, by providing them in a `.csv` file through the `--input` parameter.
-It has to be a comma-separated file with four or five columns, and a header row as shown in the examples below.
+It has to be a comma-separated file with four columns, and a header row as shown in the examples below.
 
 ```console
-species_dir,assembly_name,assembly_accession,ensembl_species_name,annotation_method
-25g/data/echinoderms/Asterias_rubens,eAstRub1.3,GCA_902459465.3,Asterias_rubens,refseq
-25g/data/insects/Osmia_bicornis,iOsmBic2.1,GCA_907164935.1,Osmia_bicornis_bicornis,ensembl
-25g/data/insects/Osmia_bicornis,iOsmBic2.1_alternate_haplotype,GCA_907164925.1,Osmia_bicornis_bicornis,ensembl
-darwin/data/insects/Noctua_fimbriata,ilNocFimb1.1,GCA_905163415.1,Noctua_fimbriata,braker
+outdir,assembly_accession,ensembl_species_name,annotation_method
+Asterias_rubens/eAstRub1.3,GCA_902459465.3,Asterias_rubens,refseq
+Osmia_bicornis/iOsmBic2.1,GCA_907164935.1,Osmia_bicornis_bicornis,ensembl
+Osmia_bicornis/iOsmBic2.1_alternate_haplotype,GCA_907164925.1,Osmia_bicornis_bicornis,ensembl
+Noctua_fimbriata/ilNocFimb1.1,GCA_905163415.1,Noctua_fimbriata,braker
 ```
 
-| Column                 | Description                                                                                                                                                |
-| ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `species_dir`          | Output directory for this species (evaluated from `--outdir` if a relative path). Analysis results are deposited in `analysis/$assembly_name/`.            |
-| `assembly_name`        | Name of the assembly. Used to build the actual output directory.                                                                                           |
-| `assembly_accession`   | (Optional). Accession number of the assembly to download. Typically of the form `GCA_*.*`. If missing, the pipeline will infer it from the ACCESSION file. |
-| `ensembl_species_name` | Name of the species, _as used by Ensembl_. Note: it may differ from Tree of Life's                                                                         |
-| `annotation_method`    | Name of the method of the geneset that holds the repeat annotation.                                                                                        |
+| Column                 | Description                                                                                                                                     |
+| ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `outdir`               | Output directory for this annotation (evaluated from `--outdir` if a relative path). Analysis results are in a sub-directory `repeats/ensembl`. |
+| `assembly_accession`   | Accession number of the assembly to download. Typically of the form `GCA_*.*`. If missing, the pipeline will infer it from the ACCESSION file.  |
+| `ensembl_species_name` | Name of the species, _as used by Ensembl_. Note: it may differ from Tree of Life's                                                              |
+| `annotation_method`    | Name of the method of the geneset that holds the repeat annotation.                                                                             |
 
 A samplesheet may contain:
 
@@ -69,9 +68,7 @@ A samplesheet may contain:
 - only one row per assembly
 
 All samplesheet columns correspond exactly to their corresponding command-line parameter,
-except `species_dir` which overrides or complements `--oudir`.
-`species_dir` is used to fit the output of this pipeline into a directory structure compatible with the other pipelines
-from Sanger Tree of Life.
+except `outdir` which, if a relative path, is interpreted under `--oudir`.
 
 An [example samplesheet](../assets/samplesheet.csv) has been provided with the pipeline.
 
@@ -105,8 +102,8 @@ nextflow run sanger-tol/ensemblrepeatdownload -profile docker -params-file param
 with `params.yaml` containing:
 
 ```yaml
-ensembl_species_name: "Noctua_fimbriata"
 assembly_accession: "GCA_905163415.1"
+ensembl_species_name: "Noctua_fimbriata"
 annotation_method: "braker"
 outdir: "./results/"
 ```

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -44,7 +44,7 @@
                     "pattern": "^\\S+\\.csv$",
                     "schema": "assets/schema_input.json",
                     "description": "Path to comma-separated file containing information about the assemblies to download. Used for bulk download of many assemblies.",
-                    "help_text": "The file has to be a comma-separated file with five columns, and a header row. The columns names must be `species_dir`, `assembly_name`, `ensembl_species_name`, and `annotation_method`. An additional `assembly_accession` column can be provided too.",
+                    "help_text": "The file has to be a comma-separated file with four columns, and a header row. The columns names must be `outdir`, `assembly_accession`, `ensembl_species_name`, and `annotation_method`.",
                     "fa_icon": "fas fa-file-csv"
                 },
                 "ftp_root": {

--- a/subworkflows/local/download.nf
+++ b/subworkflows/local/download.nf
@@ -8,7 +8,7 @@ include { ENSEMBL_GENOME_DOWNLOAD       } from '../../modules/local/ensembl_geno
 workflow DOWNLOAD {
 
     take:
-    repeat_params  // tuple(analysis_dir, ensembl_species_name, assembly_accession, annotation_method)
+    repeat_params  // tuple(outdir, assembly_accession, ensembl_species_name, annotation_method)
 
 
     main:
@@ -16,9 +16,10 @@ workflow DOWNLOAD {
 
     ch_genome_fasta     = ENSEMBL_GENOME_DOWNLOAD (
         repeat_params.map {
-            species_dir,
-            ensembl_species_name,
+
+            outdir,
             assembly_accession,
+            ensembl_species_name,
             annotation_method
 
             -> [
@@ -26,7 +27,7 @@ workflow DOWNLOAD {
                 [
                     id: assembly_accession + ".masked.ensembl",
                     method: annotation_method,
-                    outdir: species_dir,
+                    outdir: outdir,
                 ],
 
                 // e.g. https://ftp.ensembl.org/pub/rapid-release/species/Agriopis_aurantiaria/GCA_914767915.1/braker/genome/Agriopis_aurantiaria-GCA_914767915.1-softmasked.fa.gz

--- a/subworkflows/local/params_check.nf
+++ b/subworkflows/local/params_check.nf
@@ -19,19 +19,13 @@ workflow PARAMS_CHECK {
     if (samplesheet) {
         SAMPLESHEET_CHECK ( file(samplesheet, checkIfExists: true) )
             .csv
-            // Provides species_dir, assembly_name, assembly_accession (optional), ensembl_species_name, and annotation_method
+            // Provides outdir, assembly_accession, ensembl_species_name, and annotation_method
             .splitCsv ( header:true, sep:',' )
-            .map {
-                // If assembly_accession is missing, load the accession number from file, following the Tree of Life directory structure
-                it["assembly_accession"] ? it : it + [
-                    assembly_accession: file("${it["species_dir"]}/assembly/release/${it["assembly_name"]}/insdc/ACCESSION", checkIfExists: true).text.trim(),
-                ]
-            }
             // Convert to tuple, as required by the download subworkflow
             .map { [
-                (it["species_dir"].startsWith("/") ? "" : outdir + "/") + "${it["species_dir"]}/analysis/${it["assembly_name"]}",
-                it["ensembl_species_name"],
+                (it["outdir"].startsWith("/") ? "" : outdir + "/") + it["outdir"],
                 it["assembly_accession"],
+                it["ensembl_species_name"],
                 it["annotation_method"],
             ] }
             .set { ch_inputs }
@@ -45,7 +39,7 @@ workflow PARAMS_CHECK {
 
 
     emit:
-    ensembl_params  = ch_inputs        // tuple(analysis_dir, ensembl_species_name, assembly_accession, annotation_method)
+    ensembl_params  = ch_inputs        // tuple(outdir, ensembl_species_name, assembly_accession, annotation_method)
     versions        = ch_versions      // channel: versions.yml
 }
 

--- a/workflows/ensemblrepeatdownload.nf
+++ b/workflows/ensemblrepeatdownload.nf
@@ -48,8 +48,8 @@ workflow ENSEMBLREPEATDOWNLOAD {
         params.input,
         Channel.of(
             [
-                params.ensembl_species_name,
                 params.assembly_accession,
+                params.ensembl_species_name,
                 params.annotation_method,
             ]
         ),


### PR DESCRIPTION
As per https://jira.sanger.ac.uk/browse/TOLIT-1559 we want the output directories to be "analysis" directories rather than "species" directories.

I'm using the convention that I'm already using in the sequencecomposition pipeline: each assembly has got its own `outdir` in its `meta`. So essentially, the output directories are defined as `meta.outdir` which either comes from the `outdir` column of the sample-sheet, or from the `--outdir` command-line parameter for one-off downloads.

I have also removed the mechanism to automatically find the accession number from the `ACCESSION` file when the output directory matches the ToL structure. The accession number will be available and it's better to be explicit.

<!--
# sanger-tol/ensemblrepeatdownload pull request

Many thanks for contributing to sanger-tol/ensemblrepeatdownload!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/sanger-tol/ensemblrepeatdownload/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/sanger-tol/ensemblrepeatdownload/tree/master/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
